### PR TITLE
add simple if to keep the same path if already home

### DIFF
--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -172,7 +172,9 @@ export default class MainLayout extends Vue {
 	}
 
 	home() {
-		router.push('/')
+		if (this.$route.path != '/') {
+			router.push('/')
+		}
 	}
 
 	depositBAN() {


### PR DESCRIPTION
This fixes the navigation duplication message currently displayed when trying to push the `/` route when already on `/`.