### PR TITLE
Update Farm.vue to use New SpookySwap URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.1.0
+## Improvements
+- swaps also work with native crypto
+
 # v2.0.4
 ## Bugs
 - Link for View after a farm deposit transaction is broken #91

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.1.1
+## Improvements
+- Updated Fantom 'Add Liquidity' button to use new SpookySwap URL
+
 # v2.1.0
 ## Improvements
 - swaps also work with native crypto

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "frontend",
-	"version": "2.0.4",
+	"version": "2.1.0",
 	"private": true,
 	"scripts": {
 		"serve": "vue-cli-service serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wban-smart-contract",
-	"version": "2.0.4",
+	"version": "2.1.0",
 	"description": "dApp for swapping BAN to wBAN on Binance Smart Chain",
 	"author": "Wrap That Potassium <wrap-that-potassium@protonmail.com>",
 	"license": "GPL-3.0-or-later",


### PR DESCRIPTION
**Issue**
The "Add Liquidity" button for Fantom Farms directs the user to https://spookyswap.finance/ where the user is presented with a warning message stating the following: 
> The SpookySwap URL is migrating to https://spooky.fi This URL will no longer receive updates.


**Solution**
Updated the SpookySwap URL in Farm.vue to point to the new, updated URL provided by SpookySwap (https://spooky.fi/). Updates are located at lines 341 and 348.

**SpookySwap Message**

![SpookySwap Migration](https://user-images.githubusercontent.com/77074857/167238835-9255da6a-53b2-4472-8c60-78bdd8a05a85.png)